### PR TITLE
Send signature separately from the rest of the poem

### DIFF
--- a/inc/generation_functions.js
+++ b/inc/generation_functions.js
@@ -85,7 +85,7 @@ function generatePoem(author, mood, callback) {
             var signature = generateSignature(author);
 
             if (signature) {
-                poem["poem"]["lines"].push(signature)
+                poem["poem"]["signature"] = signature
             }
 
             return callback(poem)
@@ -330,9 +330,7 @@ function getLineStyle(phrase, author) {
 
 function generateSignature(author) {
   if (author == 'rupiKaur') {
-    return {
-      "text": '- rupi kaur'
-    }
+    return '- rupi kaur'
   }
 
   return null;

--- a/src/dictionary/dictionary.json
+++ b/src/dictionary/dictionary.json
@@ -39,6 +39,7 @@
       "romance": ["basic", "love"],
       "scent": ["love"],
       "shadow": ["angst"],
+      "skill": ["basic", "love"],
       "sport": ["basic"],
       "struggle": ["basic", "angst"],
       "stupidity": ["angst"],

--- a/src/dictionary/phrases.json
+++ b/src/dictionary/phrases.json
@@ -19,7 +19,7 @@
 		{ "phrase": "adjective concreteNoun.", "placement": ["title"] },
 		{ "phrase": "adjective bodyPart.", "placement": ["title", "beginning", "middle", "end"] },
 		{ "phrase": "adverb and adverb adjective.", "placement": ["middle"] },
-    { "phrase": "adverb and adverb subjectivePronoun infinitiveVerb.", "placement": ["middle"] },
+    { "phrase": "adverb and adverb subjectivePronoun infinitiveVerbverbEnding.", "placement": ["middle"] },
 		{ "phrase": "bodyParts.", "placement": ["title", "beginning"] },
     { "phrase": "bodyParts adverb feeling.", "placement": ["beginning", "middle"] },
 		{ "phrase": "color canvas.", "placement": ["title"] },


### PR DESCRIPTION
The twitter bot posting signatures isn't great. The server should send the signature as a separate part of the response so we can decide whether or not to include it later.